### PR TITLE
fix: Hide helpdesk previews

### DIFF
--- a/src/discord/help-desk.ts
+++ b/src/discord/help-desk.ts
@@ -322,9 +322,9 @@ export class DiscordHelpDesk {
 
     const tasks = [
       `verified I'm on the latest release(note that mobile app releases may take some time).`,
-      `read applicable [release notes](${Constants.Urls.Release}).`,
-      `reviewed the [FAQs](${Constants.Urls.Docs.FAQ}) for known issues.`,
-      `reviewed [Github](${Constants.Urls.Issues}) for known issues.`,
+      `read applicable [release notes](<${Constants.Urls.Release}>).`,
+      `reviewed the [FAQs](<${Constants.Urls.Docs.FAQ}>) for known issues.`,
+      `reviewed [Github](<${Constants.Urls.Issues}>) for known issues.`,
       'tried accessing Immich via local ip (without a custom reverse proxy).',
       'uploaded the relevant information (see below).',
       'tried an incognito window, disabled extensions, cleared mobile app cache, logged out and back in, different browsers, etc. as applicable',
@@ -335,10 +335,10 @@ export class DiscordHelpDesk {
 
 Thanks for reaching out to us. Please carefully read this message and follow the recommended actions. This will help us be more effective in our support effort and leave more time for building Immich ${Constants.Icons.Immich}.
 ## References
-- __Container Logs:__ \`docker compose logs\` [docs](${Constants.Urls.Docs.Logs})
-- __Container Status__:  \`docker ps -a\` [docs](${Constants.Urls.Docs.Containers})
-- __Reverse Proxy:__ ${Constants.Urls.Docs.ReverseProxy}
-- __Code Formatting__ ${Constants.Urls.Formatting}`,
+- __Container Logs:__ \`docker compose logs\` [docs](<${Constants.Urls.Docs.Logs}>)
+- __Container Status__:  \`docker ps -a\` [docs](<${Constants.Urls.Docs.Containers}>)
+- __Reverse Proxy:__ <${Constants.Urls.Docs.ReverseProxy}>
+- __Code Formatting__ <${Constants.Urls.Formatting}>`,
       `
 
 ## Checklist


### PR DESCRIPTION
Putting links in < > should hide the previews again.