### PR TITLE
fix: use only filename if extension is missing for code snippets

### DIFF
--- a/src/services/discord.service.ts
+++ b/src/services/discord.service.ts
@@ -333,7 +333,7 @@ export class DiscordService {
 
       const { org, repo, ref, path, lineFrom, lineTo } = match.groups;
 
-      const extension = path.split('/').pop().split('.').pop();
+      const extension = path.split('/').pop()?.split('.').pop();
       if (!extension) {
         continue;
       }

--- a/src/services/discord.service.ts
+++ b/src/services/discord.service.ts
@@ -333,7 +333,7 @@ export class DiscordService {
 
       const { org, repo, ref, path, lineFrom, lineTo } = match.groups;
 
-      const extension = path.split('.').pop();
+      const extension = path.split('/').pop().split('.').pop();
       if (!extension) {
         continue;
       }


### PR DESCRIPTION
Previously it would use the full path